### PR TITLE
Improve static support

### DIFF
--- a/lib/PearlBee.pm
+++ b/lib/PearlBee.pm
@@ -11,6 +11,8 @@ use Dancer2::Plugin::DBIC;
 BEGIN {
     use RBAC::Tiny;
     set rbac => RBAC::Tiny->new( roles => config()->{'permissions'} || {} );
+
+    our $is_static = config->{static} || '';
 }
 
 # has to be *after* the configuration is set above

--- a/lib/PearlBee/Dashboard.pm
+++ b/lib/PearlBee/Dashboard.pm
@@ -3,13 +3,17 @@ use Dancer2 appname => 'PearlBee';
 use Dancer2::Plugin::DBIC;
 use Dancer2::Plugin::Auth::Tiny;
 
-use PearlBee::Password;
-use PearlBee::Dashboard::Posts;
-use PearlBee::Dashboard::Users;
-use PearlBee::Dashboard::Comments;
-use PearlBee::Dashboard::Categories;
-use PearlBee::Dashboard::Tags;
-use PearlBee::Dashboard::Settings;
+# the dashboard only makes sens for logged in users
+if ( !$PearlBee::is_static ) {
+
+# do not load in static context
+require PearlBee::Password;
+require PearlBee::Dashboard::Posts;
+require PearlBee::Dashboard::Users;
+require PearlBee::Dashboard::Comments;
+require PearlBee::Dashboard::Categories;
+require PearlBee::Dashboard::Tags;
+require PearlBee::Dashboard::Settings;
 
 # it is how we're using Auth::Tiny in the code
 # so we configure it in the code as well
@@ -112,5 +116,7 @@ prefix '/dashboard' => sub {
         redirect '/dashboard/edit';
     };
 };
+
+}
 
 1;

--- a/lib/PearlBee/Model/Schema/Result/Category.pm
+++ b/lib/PearlBee/Model/Schema/Result/Category.pm
@@ -165,4 +165,6 @@ sub safe_cascade_delete {
 
 sub uri { '/posts/category/' . $_[0]->slug . ( $PearlBee::is_static && '.html ' ) }
 
+sub edit_uri { '/dashboard/categories/edit/' . $_[0]->id }
+
 1;

--- a/lib/PearlBee/Model/Schema/Result/Category.pm
+++ b/lib/PearlBee/Model/Schema/Result/Category.pm
@@ -163,4 +163,6 @@ sub safe_cascade_delete {
     $self->delete();
 }
 
+sub uri { '/posts/category/' . $_[0]->slug . ( $PearlBee::is_static && '.html ' ) }
+
 1;

--- a/lib/PearlBee/Model/Schema/Result/Category.pm
+++ b/lib/PearlBee/Model/Schema/Result/Category.pm
@@ -167,4 +167,6 @@ sub uri { '/posts/category/' . $_[0]->slug . ( $PearlBee::is_static && '.html ' 
 
 sub edit_uri { '/dashboard/categories/edit/' . $_[0]->id }
 
+sub delete_uri { '/dashboard/categories/delete/' . $_[0]->id }
+
 1;

--- a/lib/PearlBee/Model/Schema/Result/Post.pm
+++ b/lib/PearlBee/Model/Schema/Result/Post.pm
@@ -287,4 +287,6 @@ sub is_authorized {
   return $authorized;
 }
 
+sub uri { '/posts/' . $_[0]->slug . ( $PearlBee::is_static && '.html ' ) }
+
 1;

--- a/lib/PearlBee/Model/Schema/Result/Post.pm
+++ b/lib/PearlBee/Model/Schema/Result/Post.pm
@@ -289,4 +289,6 @@ sub is_authorized {
 
 sub uri { '/posts/' . $_[0]->slug . ( $PearlBee::is_static && '.html ' ) }
 
+sub edit_uri { '/dashboard/posts/edit/' . $_[0]->slug }
+
 1;

--- a/lib/PearlBee/Model/Schema/Result/Tag.pm
+++ b/lib/PearlBee/Model/Schema/Result/Tag.pm
@@ -100,4 +100,6 @@ __PACKAGE__->many_to_many("posts", "post_tags", "post");
 
 sub uri { '/posts/tag/' . $_[0]->slug . ( $PearlBee::is_static && '.html ' ) }
 
+sub edit_uri { '/dashboard/tags/edit/' . $_[0]->id }
+
 1;

--- a/lib/PearlBee/Model/Schema/Result/Tag.pm
+++ b/lib/PearlBee/Model/Schema/Result/Tag.pm
@@ -102,4 +102,6 @@ sub uri { '/posts/tag/' . $_[0]->slug . ( $PearlBee::is_static && '.html ' ) }
 
 sub edit_uri { '/dashboard/tags/edit/' . $_[0]->id }
 
+sub delete_uri { '/dashboard/tags/delete/' . $_[0]->id }
+
 1;

--- a/lib/PearlBee/Model/Schema/Result/Tag.pm
+++ b/lib/PearlBee/Model/Schema/Result/Tag.pm
@@ -98,4 +98,6 @@ __PACKAGE__->many_to_many("posts", "post_tags", "post");
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 
+sub uri { '/posts/tag/' . $_[0]->slug . ( $PearlBee::is_static && '.html ' ) }
+
 1;

--- a/lib/PearlBee/Model/Schema/Result/User.pm
+++ b/lib/PearlBee/Model/Schema/Result/User.pm
@@ -331,4 +331,6 @@ sub allow {
   $self->update({ status => 'deactivated' });
 }
 
+sub uri { '/posts/user/' . $_[0]->username . ( $PearlBee::is_static && '.html ' ) }
+
 1;

--- a/views/theme/header.tt
+++ b/views/theme/header.tt
@@ -12,7 +12,7 @@
                 <div class="navis">
                 </div>
             </div>
-              
+[% UNLESS settings.static %]
             [% IF settings.multiuser %]
                 <div class="register_links">
                     [% IF vars.user.username %]
@@ -72,5 +72,6 @@
                     </div>
                 </div>
             [% END %]
+[% END %]
     </div>
 </div>


### PR DESCRIPTION
This PR is related to xsawyerx/PearlBee#19.

Summary of changes:
- Static status is stored in the global `$PearlBee::is_static` variable.
- All relevant objects have gained `uri`, `edit_uri`, and `delete_uri` methods, to simplify link creation in the templates.
- The `PearlBee::Dashboard` modules are not loaded if `static = 1`, so the `/dashboard/` URL will all return 404 errors.
- The dynamic navigation links in the header are not shown in static mode.

The remaining work is to fix the templates to use the various `uri` methods.
