### PR TITLE
Fix logic for when to load PearlBee::Dashboard

### DIFF
--- a/lib/PearlBee.pm
+++ b/lib/PearlBee.pm
@@ -24,7 +24,7 @@ use PearlBee::Users;
 use PearlBee::Authors;
 use PearlBee::Categories;
 use PearlBee::Tags;
-use if $PearlBee::is_static, 'PearlBee::Dashboard';
+use if !$PearlBee::is_static, 'PearlBee::Dashboard';
 
 hook before => sub {
     my $settings = resultset('Setting')->first;


### PR DESCRIPTION
We were loading the Dashboard only when the site was static, which is exactly the opposite of what we wanted.
