### PR TITLE
Remove some hard-coded values

### DIFF
--- a/lib/PearlBee.pm
+++ b/lib/PearlBee.pm
@@ -14,6 +14,10 @@ BEGIN {
     set rbac => RBAC::Tiny->new( roles => config()->{'permissions'} || {} );
 
     our $is_static = config->{static} || '';
+
+    # some defaults
+    setting( posts_on_page => 5 ) if !config->{posts_on_page};
+    setting( pages_per_set => 7 ) if !config->{pages_per_set};
 }
 
 # has to be *after* the configuration is set above

--- a/lib/PearlBee/Comments/Builtin/Dashboard.pm
+++ b/lib/PearlBee/Comments/Builtin/Dashboard.pm
@@ -36,7 +36,7 @@ prefix '/dashboard/comments' => sub {
     get '/?' => needs_permission view_comment => sub {
         my $page   = query_parameters->{'page'}   || 1;
         my $status = query_parameters->{'status'} || '';
-        my $nr_of_rows = 5;
+        my $nr_of_rows = config->{posts_on_page};
         my $search_parameters = $status ? { status => $status } : {};
 
         my @comments = resultset('Comment')->search(
@@ -70,7 +70,7 @@ prefix '/dashboard/comments' => sub {
         my $total_comments = $all;
         my $posts_per_page = $nr_of_rows;
         my $current_page   = $page;
-        my $pages_per_set  = 7;
+        my $pages_per_set  = config->{pages_per_set};
         my $pagination     = generate_pagination_numbering(
             $total_comments, $posts_per_page,
             $current_page,   $pages_per_set

--- a/lib/PearlBee/Dashboard/Posts.pm
+++ b/lib/PearlBee/Dashboard/Posts.pm
@@ -37,7 +37,7 @@ prefix '/dashboard/posts' => sub {
     get '/?' => needs_permission view_post => sub {
         my $page   = query_parameters->{'page'}   || 1;
         my $status = query_parameters->{'status'} || '';
-        my $nr_of_rows = 5;
+        my $nr_of_rows = config->{posts_on_page};
         my $search_parameters = $status ? { status => $status } : {};
 
         my @posts = resultset('Post')->search(
@@ -69,7 +69,7 @@ prefix '/dashboard/posts' => sub {
         my $total_posts    = $all;
         my $posts_per_page = $nr_of_rows;
         my $current_page   = $page;
-        my $pages_per_set  = 7;
+        my $pages_per_set  = config->{pages_per_set};
         my $pagination
             = generate_pagination_numbering( $total_posts, $posts_per_page,
             $current_page, $pages_per_set );

--- a/lib/PearlBee/Dashboard/Users.pm
+++ b/lib/PearlBee/Dashboard/Users.pm
@@ -39,7 +39,7 @@ prefix '/dashboard/users' => sub {
     get '/?' => needs_permission view_user => sub {
         my $page       = query_parameters->{'page'} || 1;
         my $status     = query_parameters->{'status'};
-        my $nr_of_rows = 5;
+        my $nr_of_rows = config->{posts_on_page};
 
         my $search_parameters = {};
 
@@ -93,7 +93,7 @@ prefix '/dashboard/users' => sub {
         my $total_users    = $all;
         my $posts_per_page = $nr_of_rows;
         my $current_page   = $page;
-        my $pages_per_set  = 7;
+        my $pages_per_set  = config->{pages_per_set};
         my $pagination
             = generate_pagination_numbering( $total_users, $posts_per_page,
             $current_page, $pages_per_set );

--- a/lib/PearlBee/Posts.pm
+++ b/lib/PearlBee/Posts.pm
@@ -10,8 +10,7 @@ use PearlBee::Helpers::Captcha;
 
 prefix '/posts' => sub {
     get '' => sub {
-        my $nr_of_rows
-            = config->{'posts_on_page'} || 5; # Number of posts per page
+        my $nr_of_rows = config->{'posts_on_page'};
         my $page = query_parameters->{'page'} || 1; # for paging
         my @posts = resultset('Post')->search(
             { status => 'published' },


### PR DESCRIPTION
`$nr_of_rows` and `$pages_per_set` where respectively set to 5 and 7
in several files.

Since `$nr_of_rows` was set to `config->{posts_on_page}` in
`lib/PearlBee/Posts.pm`, the obvious fix was to follow that example and
make those values configurable in the main `config.yml`.

Defaults are assigned at the application startup, so there is no need
to further check if the values are valid.

`posts_on_page` still has a number of issues:
- it should probably be named `posts_per_page`
- it is actually used different things, like limiting the number of
  users or comments shown in the dashboard

Further improvements include the addition of `users_per_page`,
`comments_per_page`, etc.

This fixes #1.
